### PR TITLE
Fix game incorrectly saying that the last player to play on diagonals won

### DIFF
--- a/tictactoe.js
+++ b/tictactoe.js
@@ -37,9 +37,9 @@ $(function(){
       }
 
       // Check diagonals
-      if($(cells[0]).text() === turn && $(cells[4]).text() === turn && $(cells[8]).text())
+      if($(cells[0]).text() === turn && $(cells[4]).text() === turn && $(cells[8]).text() === turn)
         win = true;
-      if($(cells[2]).text() === turn && $(cells[4]).text() === turn && $(cells[6]).text())
+      if($(cells[2]).text() === turn && $(cells[4]).text() === turn && $(cells[6]).text() === turn)
         win = true;
 
       // Print win or next turn


### PR DESCRIPTION
This happened when both players played on any diagonal because the code was just checking cells 6 and 8 for text, not text that was equal to the turn of the correct player.